### PR TITLE
change barometer to altimeter

### DIFF
--- a/bin/user/WLLDriver.py
+++ b/bin/user/WLLDriver.py
@@ -435,7 +435,7 @@ class WLLDriverAPI():
                             if q['sensor_type'] == 242:
                                 for pk_sensor in q['data']:
                                     if pk_sensor['ts'] == start_timestamp:
-                                        wl_packet['barometer'] = pk_sensor['bar_sea_level']
+                                        wl_packet['altimeter'] = pk_sensor['bar_sea_level']
                                         wl_packet['pressure'] = pk_sensor['bar_absolute']
 
                             if q['sensor_type'] == 243:
@@ -587,7 +587,7 @@ class WLLDriverAPI():
 
                         # Next lines are not extra, so no need ID
                         if s['data_structure_type'] == 3:
-                            wll_packet['barometer'] = s['bar_sea_level']
+                            wll_packet['altimeter'] = s['bar_sea_level']
                             wll_packet['pressure'] = s['bar_absolute']
 
                         if s['data_structure_type'] == 4:


### PR DESCRIPTION
The WLL spec sheet says : Sea-Level Reduction Equation Used. . . . . . . . . Altimeter
(https://www.davisinstruments.com/product_documents/weather/spec_sheets/6100_WL-Live_Spec_Sheet.pdf)
Tested on my configuration and the value of "new" barometer (computed by weewx) is now exactly the same as near meteo france station